### PR TITLE
fixed _mergeHeader function.

### DIFF
--- a/lib/src/http_transport.dart
+++ b/lib/src/http_transport.dart
@@ -38,8 +38,12 @@ class HttpTransport implements Transport {
   }
 
   Map<String, String> _mergeHeader(Map<String, String> headerToMerge) {
-    return _basicAuth == null ? headerToMerge : Map.from(_basicAuth.toMap())
-      ..addAll(headerToMerge);
+    if (_basicAuth != null) {
+      Map<String, String> headers = Map<String, String>.from(_basicAuth.toMap());
+      headers.addAll(headerToMerge);
+      return headers;
+    }
+    return headerToMerge;
   }
 }
 


### PR DESCRIPTION
The _mergeHeader function was throwing an error - `addAll is being called on null`. This used to occur whenever deleteIndex or flushIndex were executed. The cause of this issue was using addAll on a map which would return void instead of returning the map with added data itself.