### PR TITLE
Add 'source' param, deprecate 'fetchSource' param for Client.search()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.5
+
+- Add dynamic `source` param for Client.search() method. This is a replacement for the boolean `fetchSource` to allow _source to be a boolean, a string or a list of strings as per the Elasticsearch spec.
+- Deprecate `fetchSource` param in the Client.search() method.
+
 ## 0.1.4
 
 - Fixed `_mergeHeader` function.

--- a/lib/src/elastic_client_impl.dart
+++ b/lib/src/elastic_client_impl.dart
@@ -103,10 +103,14 @@ class Client {
   }
 
   Future<SearchResult> search(String index, String type, Map query,
-      {int offset, int limit, bool fetchSource = false, Map suggest}) async {
+      {int offset,
+      int limit,
+      @Deprecated("Use 'source' instead") bool fetchSource = false,
+      dynamic source,
+      Map suggest}) async {
     final path = [index, type, '_search'];
     final map = {
-      '_source': fetchSource,
+      '_source': source ?? fetchSource,
       'query': query,
       'from': offset,
       'size': limit,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: elastic_client
 description: >
   Dart bindings for ElasticSearch HTTP API.
   ElasticSearch is a full-text search engine based on Lucene.
-version: 0.1.4
+version: 0.1.5
 homepage: https://github.com/isoos/elastic_client
 author: Istvan Soos <istvan.soos@gmail.com>
 


### PR DESCRIPTION
As per issue #7 