### PR TITLE
add scroll search

### DIFF
--- a/lib/src/elastic_client_impl.dart
+++ b/lib/src/elastic_client_impl.dart
@@ -201,35 +201,19 @@ class Client {
       'aggregations': aggregations,
     };
     map.removeWhere((k, v) => v == null);
-    final params = {'search_type': 'dfs_query_then_fetch'};
-    if (scroll != null) {
-      params['scroll'] = scroll.inSeconds.toString() + 's';
-    }
+    final params = {
+      'search_type': 'dfs_query_then_fetch',
+      if (scroll != null) 'scroll': scroll.inSeconds.toString() + 's',
+    };
     final rs = await _transport
         .send(Request('POST', path, params: params, bodyMap: map));
     if (rs.statusCode != 200) {
       throw Exception('Failed to search $query');
     }
-    final body = convert.json.decode(rs.body);
-    final hitsMap = body['hits'] ?? const {};
-    final hitsTotal = hitsMap['total'];
-    var totalCount = 0;
-    if (hitsTotal is int) {
-      totalCount = hitsTotal;
-    } else if (hitsTotal is Map) {
-      totalCount = (hitsTotal['value'] as int) ?? 0;
-    }
-    final hitsList = (hitsMap['hits'] as List).cast<Map>() ?? const <Map>[];
-    final results = hitsList
-        .map((Map map) => Doc(
-              map['_id'] as String,
-              map['_source'] as Map,
-              index: map['_index'] as String,
-              type: map['_type'] as String,
-              score: map['_score'] as double,
-              sort: map['sort'] as List<dynamic>,
-            ))
-        .toList();
+    final body = convert.json.decode(rs.body) as Map<String, dynamic>;
+    final hitsMap = body['hits'] as Map<String, dynamic> ?? const {};
+    final totalCount = _extractTotalCount(hitsMap);
+    final results = _extractDocList(hitsMap);
     final suggestMap = body['suggest'] as Map ?? const {};
     final suggestHits = suggestMap.map<String, List<SuggestHit>>((k, v) {
       if (v == null) return null;
@@ -270,45 +254,29 @@ class Client {
       results,
       suggestHits: suggestHits.isEmpty ? null : suggestHits,
       aggregations: aggResult.isEmpty ? null : aggResult,
-      scrollId: body['_scroll_id'] as String ?? null,
+      scrollId: body['_scroll_id'] as String,
     );
   }
 
   Future<SearchResult> scroll(String scrollId, Duration scroll) async {
     final path = ['_search', 'scroll'];
-    final bodyMap = {'scroll_id': scrollId};
-    if (scroll != null) {
-      bodyMap['scroll'] = scroll.inSeconds.toString() + 's';
-    }
+    final bodyMap = {
+      'scroll_id': scrollId,
+      'scroll': scroll.inSeconds.toString() + 's',
+    };
     final rs = await _transport.send(Request('GET', path, bodyMap: bodyMap));
     if (rs.statusCode != 200) {
       throw Exception('Failed to search scroll');
     }
-    final body = convert.json.decode(rs.body);
-    final hitsMap = body['hits'] ?? const {};
-    final hitsTotal = hitsMap['total'];
-    var totalCount = 0;
-    if (hitsTotal is int) {
-      totalCount = hitsTotal;
-    } else if (hitsTotal is Map) {
-      totalCount = (hitsTotal['value'] as int) ?? 0;
-    }
-    final hitsList = (hitsMap['hits'] as List).cast<Map>() ?? const <Map>[];
-    final results = hitsList
-        .map((Map map) => Doc(
-              map['_id'] as String,
-              map['_source'] as Map,
-              index: map['_index'] as String,
-              type: map['_type'] as String,
-              score: map['_score'] as double,
-              sort: map['sort'] as List<dynamic>,
-            ))
-        .toList();
+    final body = convert.json.decode(rs.body) as Map<String, dynamic>;
+    final hitsMap = body['hits'] as Map<String, dynamic> ?? const {};
+    final totalCount = _extractTotalCount(hitsMap);
+    final results = _extractDocList(hitsMap);
 
     return SearchResult(
       totalCount,
       results,
-      scrollId: body['_scroll_id'] as String ?? null,
+      scrollId: body['_scroll_id'] as String,
     );
   }
 
@@ -322,6 +290,32 @@ class Client {
     final body = convert.json.decode(rs.body);
     return ClearScrollResult(
         body['succeeded'] as bool ?? false, body['num_freed'] as int ?? 0);
+  }
+
+  int _extractTotalCount(Map<String, dynamic> hitsMap) {
+    final hitsTotal = hitsMap['total'];
+    var totalCount = 0;
+    if (hitsTotal is int) {
+      totalCount = hitsTotal;
+    } else if (hitsTotal is Map) {
+      totalCount = (hitsTotal['value'] as int) ?? 0;
+    }
+    return totalCount;
+  }
+
+  List<Doc> _extractDocList(Map<String, dynamic> hitsMap) {
+    final hitsList = (hitsMap['hits'] as List).cast<Map>() ?? const <Map>[];
+    final results = hitsList
+        .map((Map map) => Doc(
+              map['_id'] as String,
+              map['_source'] as Map,
+              index: map['_index'] as String,
+              type: map['_type'] as String,
+              score: map['_score'] as double,
+              sort: map['sort'] as List<dynamic>,
+            ))
+        .toList();
+    return results;
   }
 }
 


### PR DESCRIPTION
Hi, I added scroll search api to this client.

Paginate search results | Elasticsearch Reference [7.9] | Elastic
https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html#scroll-search-results
Scroll API | Elasticsearch Reference [7.9] | Elastic
https://www.elastic.co/guide/en/elasticsearch/reference/current/scroll-api.html
Clear scroll API | Elasticsearch Reference [7.9] | Elastic
https://www.elastic.co/guide/en/elasticsearch/reference/current/clear-scroll-api.html



Here is the example code. This code print all document id by scroll search api.
```
import 'package:elastic_client/console_http_transport.dart' as elastic;
import 'package:elastic_client/elastic_client.dart' as elastic;

Future<void> main() async {
  final transport =
      elastic.ConsoleHttpTransport(Uri.parse('http://localhost:9201'));
  final elasticClient = elastic.Client(transport);

  final index = 'test_index';
  final scroll = Duration(minutes: 3);
  final searchResult = await elasticClient.search(
    index,
    '_doc',
    elastic.Query.matchAll(),
    scroll: scroll,
  );
  for (final i in searchResult.hits) {
    print(i.id);
  }
  while (true) {
    final scrollResult =
        await elasticClient.scroll(searchResult.scrollId, scroll);
    for (final i in scrollResult.hits) {
      print(i.id);
    }
    if (scrollResult.hits.isEmpty) {
      final clearScrollResult =
          await elasticClient.clearScroll([scrollResult.scrollId]);
      print(clearScrollResult.toMap());
      break;
    }
  }
  await transport.close();
}
```