### PR TITLE
Allow nullable type on search

### DIFF
--- a/lib/src/elastic_client_impl.dart
+++ b/lib/src/elastic_client_impl.dart
@@ -190,11 +190,11 @@ class Client {
     Map aggregations,
     Duration scroll,
   }) async {
-    var path = [index, '_search'];
-
-    if (type != null) {
-      path = [index, type, '_search'];
-    }
+    final path = [
+      index,
+      if (type != null) type,
+      '_search',
+    ];
     
     final map = {
       '_source': source ?? fetchSource,

--- a/lib/src/elastic_client_impl.dart
+++ b/lib/src/elastic_client_impl.dart
@@ -179,7 +179,7 @@ class Client {
 
   Future<SearchResult> search(
     String index,
-    String? type,
+    String type,
     Map query, {
     int offset,
     int limit,

--- a/lib/src/elastic_client_impl.dart
+++ b/lib/src/elastic_client_impl.dart
@@ -190,7 +190,7 @@ class Client {
     Map aggregations,
     Duration scroll,
   }) async {
-    path = [index, '_search'];
+    var path = [index, '_search'];
 
     if (type != null) {
       path = [index, type, '_search'];

--- a/lib/src/elastic_client_impl.dart
+++ b/lib/src/elastic_client_impl.dart
@@ -179,7 +179,7 @@ class Client {
 
   Future<SearchResult> search(
     String index,
-    String type,
+    String? type,
     Map query, {
     int offset,
     int limit,
@@ -190,7 +190,12 @@ class Client {
     Map aggregations,
     Duration scroll,
   }) async {
-    final path = [index, type, '_search'];
+    path = [index, '_search'];
+
+    if (type != null) {
+      path = [index, type, '_search'];
+    }
+    
     final map = {
       '_source': source ?? fetchSource,
       'query': query,


### PR DESCRIPTION
Fixes  https://github.com/isoos/elastic_client/issues/23

To avoid forcing the type to be provided, and to embrace the deprecation of types on elasticsearch 8.0, its necessary to provide a way of not passing a type to the search method.

I wanted to just provide a default value, but Dart has this funny thing of putting all the optional parameters in the end. It also does not provide support for method overloading, so it can't be done by providing a new API without the parameter with the same name.
The only valid alternative I could find was to move the optional parameters, but that would break backward compatibility with positional arguments.

I think its better to not provide any "default" value for the type, but if the client wants to use `_doc` that can be provided explicitly. Afaik, It makes no difference in the end.