### PR TITLE
Add property 'ignoreBadCertificates' for use HTTPS transport.

### DIFF
--- a/lib/console_http_transport.dart
+++ b/lib/console_http_transport.dart
@@ -7,5 +7,5 @@ export 'elastic_client.dart';
 
 class ConsoleHttpTransport extends HttpTransport {
   ConsoleHttpTransport(Uri uri, {BasicAuth basicAuth})
-      : super(ConsoleClient(), uri, basicAuth: basicAuth);
+      : super(ConsoleClient(ignoreBadCertificates: true), uri, basicAuth: basicAuth);
 }


### PR DESCRIPTION
In connection with the http protocol blocking [https://flutter.dev/docs/release/breaking-changes/network-policy-ios-android](https://flutter.dev/docs/release/breaking-changes/network-policy-ios-android), please add the property to the transport to allow working through the HTTPS protocol with certificates not passing all the checks.