### PR TITLE
Remove all required fields from search method

### DIFF
--- a/lib/src/elastic_client_impl.dart
+++ b/lib/src/elastic_client_impl.dart
@@ -198,7 +198,7 @@ class Client {
     
     final map = {
       '_source': source ?? fetchSource,
-      'query': query ? query : new Map(),
+      'query': query ?? {},
       'from': offset,
       'size': limit,
       'suggest': suggest,

--- a/lib/src/elastic_client_impl.dart
+++ b/lib/src/elastic_client_impl.dart
@@ -177,10 +177,10 @@ class Client {
     return rs.bodyAsMap['deleted'] as int ?? 0;
   }
 
-  Future<SearchResult> search(
+  Future<SearchResult> search({
     String index,
     String type,
-    Map query, {
+    Map query, 
     int offset,
     int limit,
     @Deprecated("Use 'source' instead") bool fetchSource = false,
@@ -191,14 +191,14 @@ class Client {
     Duration scroll,
   }) async {
     final path = [
-      index,
+      if (index != null) index,
       if (type != null) type,
       '_search',
     ];
     
     final map = {
       '_source': source ?? fetchSource,
-      'query': query,
+      'query': query ? query : new Map(),
       'from': offset,
       'size': limit,
       'suggest': suggest,


### PR DESCRIPTION
Following on the last change that made the type optional, I realized the same applies to the index. One might decide to use `/_search` directly in the root, without specifying any index name in the path.

That said, since reordering the parameters is a backward compatibility problem, and one might also want to paginate through the index without searching for anything, I think it would be reasonable to also make the query optional.

This also prepares the library for a future update where one of those parameters can be removed/reordered, while still keeping the same parameter order it has at the moment.