### PR TITLE
Increase pub.dev points

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Dart bindings for ElasticSearch HTTP API.
 
 [ElasticSearch](https://www.elastic.co/) is a full-text search engine based
-on [Lucene](http://lucene.apache.org/).
+on [Lucene](https://lucene.apache.org/).
 
 ## Roadmap
 


### PR DESCRIPTION
As mentioned in pub.dev, the link to Apache lucene is not secure. This leads to a deduction of 5 points (from a total of 110). Since these points are used by pub even to display packages in order, this change adds 5 points to the current 105 points.

Make Apache Lucene link secure