### PR TITLE
Updated http_client dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   http: ^0.13.0
-  http_client: ^1.0.0
+  http_client: ^1.5.1
   meta: ^1.0.0
 
 dev_dependencies:


### PR DESCRIPTION
This PR resolves this warning
```
../../.pub-cache/hosted/pub.dartlang.org/http_client-1.5.0/lib/pkg_http_adapter.dart:33:10: Warning: Operand of null-aware operation '!' has type 'int' which excludes null.
      rs.statusCode!,
         ^
```