### PR TITLE
Add method on _query.dart to support regexp feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## 0.3.6
 
-- Supporting [Regexp query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-regexp-query.html)
-  - Added `regexp` method on [_query.dart](https://github.com/isoos/elastic_client/blob/master/lib/src/_query.dart)
+- Added `Query.regexp` method to support [regexp query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-regexp-query.html). ([#52](https://github.com/isoos/elastic_client/pull/52) by [sota1235](https://github.com/sota1235))
 
 ## 0.3.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.6
+
+- Supporting [Regexp query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-regexp-query.html)
+  - Added `regexp` method on [_query.dart](lib/src/_query.dart)
+
 ## 0.3.5
 
 - Added the very basics of `Function score query` to `Query` with the function `functionScore`. ([#50](https://github.com/isoos/elastic_client/pull/50) by [Cronos87](https://github.com/Cronos87))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.3.6
 
 - Supporting [Regexp query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-regexp-query.html)
-  - Added `regexp` method on [_query.dart](lib/src/_query.dart)
+  - Added `regexp` method on [_query.dart](https://github.com/isoos/elastic_client/blob/master/lib/src/_query.dart)
 
 ## 0.3.5
 

--- a/lib/src/_query.dart
+++ b/lib/src/_query.dart
@@ -72,6 +72,27 @@ abstract class Query {
     };
   }
 
+  static Map regexp(
+    String field,
+    String value, {
+    String? flags,
+    dynamic caseInsensitive,
+    int? maxDeterminizedStates,
+    String? rewrite,
+  }) {
+    return {
+      'regexp': {
+        field: {
+          'value': value,
+          if (flags != null) 'flags': flags,
+          if (caseInsensitive != null) 'case_insensitive': caseInsensitive,
+          if (maxDeterminizedStates != null) 'max_determinized_states': maxDeterminizedStates,
+          if (rewrite != null) 'rewrite': rewrite,
+        },
+      },
+    };
+  }
+
   static Map ids(List<String> values) => {
         'ids': {'values': values}
       };

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: elastic_client
 description: >
   Dart bindings for ElasticSearch HTTP API.
   ElasticSearch is a full-text search engine based on Lucene.
-version: 0.3.5
+version: 0.3.6
 homepage: https://github.com/isoos/elastic_client
 
 environment:


### PR DESCRIPTION
Hello,  @isoos.
I'm one of the users of this library, it's really useful so I want to say thank you to you:)

On this PR, I added a code to support the features below.

- [Regexp query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-regexp-query.html) on ElasticSearch

I need it on my project, but there is no way to use this feature via this library.
So please confirm my PR and concern to merge it(or give me a comment to fix some points)

Thank you