### PR TITLE
Add matchPhrase method on Query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.7
+
+- Added `Query.matchPhrase` method to support [match_phrase query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query-phrase.html).
+
 ## 0.3.6
 
 - Added `Query.regexp` method to support [regexp query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-regexp-query.html). ([#52](https://github.com/isoos/elastic_client/pull/52) by [sota1235](https://github.com/sota1235))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.3.7
 
 - Added `Query.matchPhrase` method to support [match_phrase query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query-phrase.html).
+  ([#54](https://github.com/isoos/elastic_client/pull/54) by [sota1235](https://github.com/sota1235))
 
 ## 0.3.6
 

--- a/lib/src/_query.dart
+++ b/lib/src/_query.dart
@@ -44,6 +44,18 @@ abstract class Query {
     };
   }
 
+  static Map matchPhrase(String field, String text, {String? analyzer, String? zeroTermsQuery}) {
+    return {
+      'match_phrase': {
+        field: {
+          'query': text,
+          if (analyzer != null) 'analyzer': analyzer,
+          if (zeroTermsQuery != null) 'zero_terms_query': zeroTermsQuery,
+        }
+      },
+    };
+  }
+
   static Map queryString(String query, {String? defaultField}) {
     return {
       'query_string': {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: elastic_client
 description: >
   Dart bindings for ElasticSearch HTTP API.
   ElasticSearch is a full-text search engine based on Lucene.
-version: 0.3.6
+version: 0.3.7
 homepage: https://github.com/isoos/elastic_client
 
 environment:


### PR DESCRIPTION
If you have any feedback, plz feel free to give it 🙇 

## What

I implemented `Query.matchPhrase` to support [match_phrase](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query-phrase.html) feature on elasticsearch.

## Why

Just I want to use this elasticsearch feature via this library :)