### PR TITLE
Receiving query parameter on count method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.8
+
+- Support `query` parameter on `Client.count` method.
+
 ## 0.3.7
 
 - Added `Query.matchPhrase` method to support [match_phrase query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query-phrase.html).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.3.8
 
-- Support `query` parameter on `Client.count` method.
+- Support `query` parameter on `Client.count` method. ([#55](https://github.com/isoos/elastic_client/pull/55) by [sota1235](https://github.com/sota1235))
 
 ## 0.3.7
 

--- a/lib/src/_client.dart
+++ b/lib/src/_client.dart
@@ -402,13 +402,11 @@ class Client {
   }
 
   /// Count the total items for the given [index].
-  Future<int> count({required String index}) async {
+  Future<int> count({required String index, Map? query}) async {
     final rs = await _transport.send(
-      Request(
-        'GET',
-        ['_count'],
-        params: {'format': 'json'},
-      ),
+      Request('GET', [index, '_count'],
+          params: {'format': 'json'},
+          bodyMap: {'query': query ?? Query.matchAll()}),
     );
     rs.throwIfStatusNotOK(message: 'Unable to count the total of items.');
     final body = rs.bodyAsMap;

--- a/lib/src/_client.dart
+++ b/lib/src/_client.dart
@@ -403,11 +403,15 @@ class Client {
 
   /// Count the total items for the given [index].
   Future<int> count({required String index, Map? query}) async {
-    final rs = await _transport.send(
-      Request('GET', [index, '_count'],
-          params: {'format': 'json'},
-          bodyMap: {'query': query ?? Query.matchAll()}),
-    );
+    final bodyMap = {
+      if (query != null) 'query': query,
+    };
+    final rs = await _transport.send(Request(
+      'GET',
+      [index, '_count'],
+      params: {'format': 'json'},
+      bodyMap: bodyMap,
+    ));
     rs.throwIfStatusNotOK(message: 'Unable to count the total of items.');
     final body = rs.bodyAsMap;
     return body['count'] as int;

--- a/lib/src/_index.dart
+++ b/lib/src/_index.dart
@@ -12,7 +12,7 @@ class IndexRef {
   Future<bool> exists() => _client.indexExists(index: name);
 
   /// Count the total items.
-  Future<int> count() => _client.count(index: name);
+  Future<int> count({Map? query}) => _client.count(index: name, query: query);
 
   /// Updates index definition with [content].
   Future<void> update({

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: elastic_client
 description: >
   Dart bindings for ElasticSearch HTTP API.
   ElasticSearch is a full-text search engine based on Lucene.
-version: 0.3.7
+version: 0.3.8
 homepage: https://github.com/isoos/elastic_client
 
 environment:


### PR DESCRIPTION
# What

- I added `query` parameter on `Client.count` method.

# Detail

As the documentation says, count API accepts the request body named `query`.
So I modified the existing method to receive that.

https://www.elastic.co/guide/en/elasticsearch/reference/current/search-count.html#search-count-request-body

This won't break backward compatibility.

Please review it 🙏 

# P.S.

I feel it's better to run tests on CI because it'll be easy to find broken code.
If you are fine, I can write GitHub actions YAML files and create new PR:)