### PR TITLE
fix deprecated field name(mustNot)

### DIFF
--- a/lib/src/_query.dart
+++ b/lib/src/_query.dart
@@ -16,7 +16,7 @@ abstract class Query {
         if (must != null) 'must': must,
         if (filter != null) 'filter': filter,
         if (should != null) 'should': should,
-        if (mustNot != null) 'mustNot': mustNot,
+        if (mustNot != null) 'must_not': mustNot,
       }
     };
   }


### PR DESCRIPTION
When I use `mustNot` query, I get the following message: Fixed to `must_not` instead of `mustNot`.

>  "Deprecated field [mustNot] used, expected [must_not] instead", "key": "deprecated_field_mustNot",