### PR TITLE
add headers to response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.12
+- Added Elasticsearch warning response header information to `Response`
+
 ## 0.3.11
 - Added support for term enum ([#62](https://github.com/isoos/elastic_client/pull/62) by [Vi-cs](https://github.com/Vi-cs))
 

--- a/lib/src/_transport.dart
+++ b/lib/src/_transport.dart
@@ -63,8 +63,11 @@ class Response {
   Map<String, dynamic>? _bodyAsMap;
   List? _bodyAsList;
 
+  /// The HTTP headers of the response.
+  final Map<String, String> headers;
+
   /// Creates a new [Response] object.
-  Response(this.statusCode, this.body);
+  Response(this.statusCode, this.body, this.headers);
 
   /// Returns the body parsed as a [Map].
   Map<String, dynamic> get bodyAsMap =>

--- a/lib/src/_transport.dart
+++ b/lib/src/_transport.dart
@@ -63,11 +63,11 @@ class Response {
   Map<String, dynamic>? _bodyAsMap;
   List? _bodyAsList;
 
-  /// The HTTP headers of the response.
-  final Map<String, String> headers;
+  /// The warning extracted from the HTTP headers of the response.
+  final String? warning;
 
   /// Creates a new [Response] object.
-  Response(this.statusCode, this.body, this.headers);
+  Response(this.statusCode, this.body, {this.warning});
 
   /// Returns the body parsed as a [Map].
   Map<String, dynamic> get bodyAsMap =>

--- a/lib/src/http_transport.dart
+++ b/lib/src/http_transport.dart
@@ -46,7 +46,7 @@ class HttpTransport implements Transport {
       rq.body = request.bodyText!;
     }
     final rs = await _httpClient.send(rq).timeout(_timeout);
-    return Response(rs.statusCode, await rs.stream.bytesToString());
+    return Response(rs.statusCode, await rs.stream.bytesToString(), rs.headers);
   }
 
   @override

--- a/lib/src/http_transport.dart
+++ b/lib/src/http_transport.dart
@@ -46,7 +46,9 @@ class HttpTransport implements Transport {
       rq.body = request.bodyText!;
     }
     final rs = await _httpClient.send(rq).timeout(_timeout);
-    return Response(rs.statusCode, await rs.stream.bytesToString(), rs.headers);
+    final warning = rs.headers['warning'];
+    return Response(rs.statusCode, await rs.stream.bytesToString(),
+        warning: warning);
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,11 +2,11 @@ name: elastic_client
 description: >
   Dart bindings for ElasticSearch HTTP API.
   ElasticSearch is a full-text search engine based on Lucene.
-version: 0.3.11
+version: 0.3.12
 homepage: https://github.com/isoos/elastic_client
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   http: ^0.13.0


### PR DESCRIPTION
In response headers, we can find deprecation logging. Please refer to [here](https://www.elastic.co/guide/en/elasticsearch/client/net-api/7.16/deprecation-logging.html).

Thus, if elastic_client has response headers, we can log it. In this case, we can find which application code send deprecation request. Without it, we should examine elasticsearch server itself. 

The following is example response header.

![image](https://user-images.githubusercontent.com/5561944/229988707-0f1b479f-af0b-4005-bedd-9976b5fa51c3.png)
